### PR TITLE
Fixed issue with reevaluating formula's when target node changes

### DIFF
--- a/src/ReactGraph.Tests/ApiTest.cs
+++ b/src/ReactGraph.Tests/ApiTest.cs
@@ -225,6 +225,8 @@ c.Value --> (c.Value * 2) --> d.Value --> (d.Value - 2) --> c.Value");
                 .Assign(() => Prop)
                 .From(() => mortgateCalculator.PaymentSchedule.HasValidationError, ex => { });
 
+            string dotFormat = engine.ToDotFormat("Foo");
+            Console.WriteLine(dotFormat);
             mortgateCalculator.PaymentSchedule.HasValidationError = true;
 
             engine.ValueHasChanged(mortgateCalculator.PaymentSchedule, "HasValidationError");
@@ -308,10 +310,12 @@ c.Value --> (c.Value * 2) --> d.Value --> (d.Value - 2) --> c.Value");
         public void ChangingTargetPropertyShouldNotTriggerExpressionEvaluation()
         {
             var optionsViewModel = new OptionsViewModel();
-
             engine
                 .Assign(() => optionsViewModel.SelectedOption)
                 .From(() => CountHowManyTimesCalled(optionsViewModel.Options), ex => { });
+
+            string dotFormat = engine.ToDotFormat("Foo");
+            Console.WriteLine(dotFormat);
 
             // reset count to 0 (because of issue 1)
             count = 0;

--- a/src/ReactGraph.Tests/ExpressionParserTest.cs
+++ b/src/ReactGraph.Tests/ExpressionParserTest.cs
@@ -18,10 +18,10 @@ namespace ReactGraph.Tests
             var subExpressions = ExpressionParser.GetChildSources(expr);
             subExpressions.Count.ShouldBe(1);
             var propertyNode = subExpressions.Single();
-            propertyNode.Path.ShouldBe("notifies.Total");
+            propertyNode.FullPath.ShouldBe("notifies.Total");
             propertyNode.SourcePaths.Count.ShouldBe(1);
             var notifiesNode = propertyNode.SourcePaths[0];
-            notifiesNode.Path.ShouldBe("notifies");
+            notifiesNode.FullPath.ShouldBe("notifies");
         }
 
         [Fact]
@@ -31,13 +31,13 @@ namespace ReactGraph.Tests
             viewModel.RegeneratePaymentSchedule(false);
             Expression<Func<bool>> expr = () => viewModel.PaymentSchedule.HasValidationError;
             var node = ExpressionParser.GetChildSources(expr).Single();
-            node.Path.ShouldBe("viewModel.PaymentSchedule.HasValidationError");
+            node.FullPath.ShouldBe("viewModel.PaymentSchedule.HasValidationError");
             node.SourcePaths.Count.ShouldBe(1);
             var paymentScheduleNode = node.SourcePaths[0];
-            paymentScheduleNode.Path.ShouldBe("viewModel.PaymentSchedule");
+            paymentScheduleNode.FullPath.ShouldBe("viewModel.PaymentSchedule");
 
             var rootNode = paymentScheduleNode.SourcePaths.Single();
-            rootNode.Path.ShouldBe("viewModel");
+            rootNode.FullPath.ShouldBe("viewModel");
             rootNode.SourcePaths.ShouldBeEmpty();
         }
 
@@ -50,14 +50,14 @@ namespace ReactGraph.Tests
             var node = ExpressionParser.GetChildSources(expr);
             node.Count.ShouldBe(1);
             var validationErrorNode = node[0];
-            validationErrorNode.Path.ShouldBe("viewModel.PaymentSchedule.HasValidationError");
+            validationErrorNode.FullPath.ShouldBe("viewModel.PaymentSchedule.HasValidationError");
             validationErrorNode.SourcePaths.Count.ShouldBe(1);
 
             var paymentScheduleNode = validationErrorNode.SourcePaths[0];
-            paymentScheduleNode.Path.ShouldBe("viewModel.PaymentSchedule");
+            paymentScheduleNode.FullPath.ShouldBe("viewModel.PaymentSchedule");
 
             var rootNode = paymentScheduleNode.SourcePaths.Single();
-            rootNode.Path.ShouldBe("viewModel");
+            rootNode.FullPath.ShouldBe("viewModel");
             rootNode.SourcePaths.ShouldBeEmpty();
         }
 
@@ -69,9 +69,9 @@ namespace ReactGraph.Tests
             var node = ExpressionParser.GetChildSources(expr);
             node.Count.ShouldBe(1);
             var valueNode = node.Single();
-            valueNode.Path.ShouldBe("simple.Value");
+            valueNode.FullPath.ShouldBe("simple.Value");
             var rootNode = valueNode.SourcePaths.Single();
-            rootNode.Path.ShouldBe("simple");
+            rootNode.FullPath.ShouldBe("simple");
             rootNode.SourcePaths.ShouldBeEmpty();
         }
 
@@ -84,14 +84,14 @@ namespace ReactGraph.Tests
             var node = ExpressionParser.GetChildSources(expr);
             node.Count.ShouldBe(2);
             var valueNode = node[0];
-            valueNode.Path.ShouldBe("simple.Value");
+            valueNode.FullPath.ShouldBe("simple.Value");
             var rootNode = valueNode.SourcePaths.Single();
-            rootNode.Path.ShouldBe("simple");
+            rootNode.FullPath.ShouldBe("simple");
             rootNode.SourcePaths.ShouldBeEmpty();
             var valueNode2 = node[1];
-            valueNode2.Path.ShouldBe("simple2.Value");
+            valueNode2.FullPath.ShouldBe("simple2.Value");
             var rootNode2 = valueNode2.SourcePaths.Single();
-            rootNode2.Path.ShouldBe("simple2");
+            rootNode2.FullPath.ShouldBe("simple2");
             rootNode2.SourcePaths.ShouldBeEmpty();
         }
 

--- a/src/ReactGraph.Tests/NotifyPropertyChangedTests.cs
+++ b/src/ReactGraph.Tests/NotifyPropertyChangedTests.cs
@@ -45,21 +45,21 @@ namespace ReactGraph.Tests
                   .From(() => !viewModel.PaymentSchedule.HasValidationError, e => { });
 
             viewModel.RegeneratePaymentSchedule(hasValidationError: true);
-            Console.WriteLine(engine.ToString());
+            Console.WriteLine(engine.ToDotFormat(string.Empty));
             viewModel.CanApply.ShouldBe(false);
             engineInstrumentation.AssertSetCount("viewModel.CanApply", 1);
 
             viewModel.RegeneratePaymentSchedule(hasValidationError: false);
-            Console.WriteLine(engine.ToString());
+            Console.WriteLine(engine.ToDotFormat(string.Empty));
             viewModel.CanApply.ShouldBe(true);
             engineInstrumentation.AssertSetCount("viewModel.CanApply", 2);
 
             viewModel.PaymentSchedule.HasValidationError = true;
-            Console.WriteLine(engine.ToString());
+            Console.WriteLine(engine.ToDotFormat(string.Empty));
             viewModel.CanApply.ShouldBe(false);
             engineInstrumentation.AssertSetCount("viewModel.CanApply", 3);
 
-            Console.WriteLine(engine.ToString());
+            Console.WriteLine(engine.ToDotFormat(string.Empty));
         }
 
         [Fact]

--- a/src/ReactGraph/DefinitionComparer.cs
+++ b/src/ReactGraph/DefinitionComparer.cs
@@ -9,7 +9,7 @@ namespace ReactGraph
         public bool Equals(IDefinitionIdentity x, IDefinitionIdentity y)
         {
             if (ReferenceEquals(x, y)) return true;
-            return string.Equals(x.Path, y.Path);
+            return string.Equals(x.FullPath, y.FullPath);
         }
 
         public int GetHashCode(IDefinitionIdentity obj)
@@ -17,7 +17,7 @@ namespace ReactGraph
             unchecked
             {
                 // TODO do we allow IDefinitionIdentity implementations to have a null path? We probably shouldn't?
-                return obj.Path != null ? obj.Path.GetHashCode() : 0;
+                return obj.FullPath != null ? obj.FullPath.GetHashCode() : 0;
             }
         }
     }

--- a/src/ReactGraph/ExpressionDefinition.cs
+++ b/src/ReactGraph/ExpressionDefinition.cs
@@ -10,16 +10,16 @@ namespace ReactGraph
         {
             NodeType = nodeType;
             NodeName = nodeName;
-            Path = ExpressionStringBuilder.ToString(expression);
+            FullPath = ExpressionStringBuilder.ToString(expression);
         }
 
-        public string Path { get; private set; }
+        public string FullPath { get; private set; }
         public string NodeName { get; private set; }
         public NodeType NodeType { get; private set; }
 
         public override string ToString()
         {
-            return Path;
+            return FullPath;
         }
     }
 }

--- a/src/ReactGraph/FormulaDefinition.cs
+++ b/src/ReactGraph/FormulaDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq.Expressions;
 using ReactGraph.NodeInfo;
 
@@ -13,6 +14,7 @@ namespace ReactGraph
             base(sourceExpression, NodeType.Formula, nodeId)
         {
             this.sourceExpression = sourceExpression;
+            PathToParent = null;
             SourcePaths = new List<ISourceDefinition>();
         }
 
@@ -20,6 +22,8 @@ namespace ReactGraph
         {
             throw new NotSupportedException("Formulas should always be re-evaluated with a provided current value.");
         }
+
+        public string PathToParent { get; private set; }
 
         public Func<T, T> CreateGetValueDelegateWithCurrentValue()
         {

--- a/src/ReactGraph/Graph/DirectedGraph.cs
+++ b/src/ReactGraph/Graph/DirectedGraph.cs
@@ -258,10 +258,10 @@ namespace ReactGraph.Graph
             return verticies[data];
         }
 
-        public IEnumerable<Vertex<T>> SuccessorsOf(T data)
+        public IEnumerable<Edge<T>> SuccessorsOf(T data)
         {
             var vertex = verticies[data];
-            return vertex.Successors.Select(e => e.Target);
+            return vertex.Successors;
         }
     }
 }

--- a/src/ReactGraph/IDefinitionIdentity.cs
+++ b/src/ReactGraph/IDefinitionIdentity.cs
@@ -4,7 +4,7 @@ namespace ReactGraph
 {
     public interface IDefinitionIdentity
     {
-        string Path { get; }
+        string FullPath { get; }
 
         string NodeName { get; }
 

--- a/src/ReactGraph/ISourceDefinition.cs
+++ b/src/ReactGraph/ISourceDefinition.cs
@@ -14,5 +14,6 @@ namespace ReactGraph
     {
         Func<T, T> CreateGetValueDelegateWithCurrentValue();
         Func<T> CreateGetValueDelegate();
+        string PathToParent { get; }
     }
 }

--- a/src/ReactGraph/MemberDefinition.cs
+++ b/src/ReactGraph/MemberDefinition.cs
@@ -15,6 +15,7 @@ namespace ReactGraph
         {
             this.targetMemberExpression = targetMemberExpression;
             this.assignmentLambda = assignmentLambda;
+            PathToParent = ((MemberExpression) targetMemberExpression.Body).Member.Name;
             SourcePaths = new List<ISourceDefinition>();
         }
 
@@ -27,6 +28,8 @@ namespace ReactGraph
         {
             return targetMemberExpression.Compile();
         }
+
+        public string PathToParent { get; private set; }
 
         public Action<T> CreateSetValueDelegate()
         {

--- a/src/ReactGraph/NodeInfo/INodeInfo.cs
+++ b/src/ReactGraph/NodeInfo/INodeInfo.cs
@@ -4,10 +4,12 @@ namespace ReactGraph.NodeInfo
     {
         NodeType Type { get; }
 
-        string Path { get; }
+        string FullPath { get; }
 
         ReevaluationResult Reevaluate();
 
         void ValueChanged();
+
+        bool PathMatches(string pathToChangedValue);
     }
 }

--- a/src/ReactGraph/NodeInfo/ReadOnlyNodeInfo.cs
+++ b/src/ReactGraph/NodeInfo/ReadOnlyNodeInfo.cs
@@ -8,13 +8,15 @@ namespace ReactGraph.NodeInfo
         readonly Maybe<T> currentValue = new Maybe<T>();
         // would be good to not have this depdendency on the repoisitory here
         readonly NodeRepository nodeRepository;
+        readonly string pathFromParent;
         readonly Func<T, T> getValue;
         bool shouldTrackChanges;
 
-        public ReadOnlyNodeInfo(Func<T, T> getValue, string path, NodeRepository nodeRepository, bool shouldTrackChanges)
+        public ReadOnlyNodeInfo(Func<T, T> getValue, string fullPath, string pathFromParent, NodeRepository nodeRepository, bool shouldTrackChanges)
         {
-            Path = path;
+            FullPath = fullPath;
             this.getValue = getValue;
+            this.pathFromParent = pathFromParent;
             this.nodeRepository = nodeRepository;
             this.shouldTrackChanges = shouldTrackChanges;
 
@@ -42,7 +44,7 @@ namespace ReactGraph.NodeInfo
             var initialValue = ((ReadWriteNode<T>) targetNode).GetValue();
             if (initialValue.HasValue)
             {
-                currentValue.NewValue(initialValue.Value);                
+                currentValue.NewValue(initialValue.Value);
             }
         }
 
@@ -50,7 +52,7 @@ namespace ReactGraph.NodeInfo
         // Also exposing a type like that means that there is a switch somewhere, which should ideally be replaced by a polymorphic call (code small?)
         public NodeType Type { get { return NodeType.Formula; } }
 
-        public string Path { get; private set; }
+        public string FullPath { get; private set; }
 
         public ReevaluationResult Reevaluate()
         {
@@ -89,6 +91,11 @@ namespace ReactGraph.NodeInfo
             }
         }
 
+        public bool PathMatches(string pathToChangedValue)
+        {
+            return pathFromParent == pathToChangedValue;
+        }
+
         IMaybe IValueSource.GetValue()
         {
             return GetValue();
@@ -97,7 +104,7 @@ namespace ReactGraph.NodeInfo
         protected bool Equals(ReadOnlyNodeInfo<T> other)
         {
             // is that enough to identify a node?
-            return string.Equals(Path, other.Path);
+            return string.Equals(FullPath, other.FullPath);
         }
 
         public override bool Equals(object obj)
@@ -110,12 +117,12 @@ namespace ReactGraph.NodeInfo
 
         public override int GetHashCode()
         {
-            return (Path != null ? Path.GetHashCode() : 0);
+            return (FullPath != null ? FullPath.GetHashCode() : 0);
         }
 
         public override string ToString()
         {
-            return Path;
+            return FullPath;
         }
     }
 }

--- a/src/ReactGraph/NodeInfo/ReadWriteNode.cs
+++ b/src/ReactGraph/NodeInfo/ReadWriteNode.cs
@@ -11,6 +11,7 @@ namespace ReactGraph.NodeInfo
 
         // TODO rename to indicate that this get and set to the corresponding member / property?
         readonly Action<T> setValue;
+        readonly string pathFromParent;
         readonly Func<T> getValue;
         readonly NodeType type;
 
@@ -20,25 +21,26 @@ namespace ReactGraph.NodeInfo
         // TODO why is the exception handler on a ReadWriteNode?
         Action<Exception> exceptionHandler;
 
-        public ReadWriteNode(Func<T> getValue, Action<T> setValue, string path, NodeType type, NodeRepository nodeRepository, bool shouldTrackChanges)
+        public ReadWriteNode(Func<T> getValue, Action<T> setValue, string fullPath, string pathFromParent, NodeType type, NodeRepository nodeRepository, bool shouldTrackChanges)
         {
-            Path = path;
+            FullPath = fullPath;
             // TODO isn't type always "member"? 
             this.type = type;
             this.nodeRepository = nodeRepository;
 
             this.shouldTrackChanges = shouldTrackChanges;
             this.setValue = setValue;
+            this.pathFromParent = pathFromParent;
             this.getValue = getValue;
             ValueChanged();
         }
 
-        public string Path { get; private set; }
+        public string FullPath { get; private set; }
 
         public void SetSource(IValueSource<T> sourceNode, Action<Exception> errorHandler)
         {
             if (valueSource != null)
-                throw new InvalidOperationException(string.Format("{0} already has a source associated with it", Path));
+                throw new InvalidOperationException(string.Format("{0} already has a source associated with it", FullPath));
 
             valueSource = sourceNode;
             exceptionHandler = errorHandler;
@@ -61,7 +63,7 @@ namespace ReactGraph.NodeInfo
 
         public override string ToString()
         {
-            return Path;
+            return FullPath;
         }
 
         // TODO always Member?
@@ -115,10 +117,15 @@ namespace ReactGraph.NodeInfo
             }
         }
 
+        public bool PathMatches(string pathToChangedValue)
+        {
+            return pathFromParent == pathToChangedValue;
+        }
+
         protected bool Equals(ReadWriteNode<T> other)
         {
             // TODO is that enough to guarantee identity?
-            return string.Equals(Path, other.Path);
+            return string.Equals(FullPath, other.FullPath);
         }
 
         public override bool Equals(object obj)
@@ -132,7 +139,7 @@ namespace ReactGraph.NodeInfo
         public override int GetHashCode()
         {
             // TODO can the path be null?
-            return (Path != null ? Path.GetHashCode() : 0);
+            return (FullPath != null ? FullPath.GetHashCode() : 0);
         }
 
         IMaybe IValueSource.GetValue()

--- a/src/ReactGraph/WriteOnlyNode.cs
+++ b/src/ReactGraph/WriteOnlyNode.cs
@@ -12,15 +12,15 @@ namespace ReactGraph
         public WriteOnlyNode(Action<T> setValue, string path)
         {
             this.setValue = setValue;
-            Path = path;
+            FullPath = path;
         }
 
-        public string Path { get; private set; }
+        public string FullPath { get; private set; }
 
         public void SetSource(IValueSource<T> sourceNode, Action<Exception> errorHandler)
         {
             if (valueSource != null)
-                throw new InvalidOperationException(string.Format("{0} already has a source associated with it", Path));
+                throw new InvalidOperationException(string.Format("{0} already has a source associated with it", FullPath));
 
             valueSource = sourceNode;
             exceptionHandler = errorHandler;
@@ -53,13 +53,18 @@ namespace ReactGraph
         {
         }
 
+        public bool PathMatches(string pathToChangedValue)
+        {
+            return false;
+        }
+
         public override string ToString()
         {
-            return Path;
+            return FullPath;
         }
         protected bool Equals(WriteOnlyNode<T> other)
         {
-            return string.Equals(Path, other.Path);
+            return string.Equals(FullPath, other.FullPath);
         }
 
         public override bool Equals(object obj)
@@ -72,7 +77,7 @@ namespace ReactGraph
 
         public override int GetHashCode()
         {
-            return (Path != null ? Path.GetHashCode() : 0);
+            return (FullPath != null ? FullPath.GetHashCode() : 0);
         }
     }
 }


### PR DESCRIPTION
This also cleans up `FindChangedNode` a heap, the logic is much simpler now. It is also faster now `Graph is 478.52x slower than manual code.`

It was about 620x after my initial refactor
